### PR TITLE
Using DATADATE as a way to preserve canonical data 

### DIFF
--- a/earningspy/calendars/earnings.py
+++ b/earningspy/calendars/earnings.py
@@ -89,6 +89,6 @@ class EarningSpy:
     @classmethod
     def _arrange(cls, data):
         data = data.set_index(FINVIZ_EARNINGS_DATE_KEY, drop=True)
-        data = data.sort_index(ascending=True)
+        data = data.sort_index(ascending=False)
         data = cls._compute_days_left(data)
         return calendar_pre_formatter(data)

--- a/earningspy/inspectors/pead.py
+++ b/earningspy/inspectors/pead.py
@@ -15,6 +15,7 @@ from earningspy.common.constants import (
     BHAR_KEY,
     ALLOWED_WINDOWS,
     AVAILABLE_CHECK_COLUMNS,
+    DATADATE_KEY
 )
 from earningspy.calendars.utils import days_left
 from earningspy.inspectors.mixins import CARMixin, TimeSeriesMixin
@@ -128,7 +129,7 @@ class PEADInspector(CARMixin, TimeSeriesMixin):
         return affected_rows
 
 
-    def join(self, storage, earnings_phase: str = "pre", keep="last"):
+    def join(self, storage, earnings_phase: str = "pre", keep="first"):
         """
         Join calendar with storage data.
 
@@ -160,7 +161,7 @@ class PEADInspector(CARMixin, TimeSeriesMixin):
 
         self.merged_data = (
             pd.concat([storage, self.calendar], join="outer")
-            .sort_values(DAYS_TO_EARNINGS_KEY_CAPITAL, ascending=False)
+            .sort_values(DATADATE_KEY, ascending=False)
             .reset_index()
             .drop_duplicates(subset=[FINVIZ_EARNINGS_DATE_KEY, TICKER_KEY_CAPITAL], keep=keep)
             .set_index(FINVIZ_EARNINGS_DATE_KEY)

--- a/earningspy/inspectors/pead.py
+++ b/earningspy/inspectors/pead.py
@@ -129,15 +129,15 @@ class PEADInspector(CARMixin, TimeSeriesMixin):
         return affected_rows
 
 
-    def join(self, storage, earnings_phase: str = "pre", keep="first"):
+    def join(self, storage, earnings_phase: str = "pre", preserve="canonical"):
         """
         Join calendar with storage data.
 
         :param storage: DataFrame with historical data
         :param earnings_phase: 'pre' or 'post'
-        :param keep: 'first' or 'last'
-            first -> preserve data from new storage values
-            last -> Preserves data from the canonical storage (default)
+        :param preserve: 'canonical' or 'incoming'
+            canonical -> preserve data from the canonical calendar (self.calendar)
+            incoming -> preserve data from storage
         """
 
         if storage is None or storage.empty:
@@ -149,21 +149,54 @@ class PEADInspector(CARMixin, TimeSeriesMixin):
         if earnings_phase not in {"pre", "post"}:
             raise ValueError("earnings_phase must be either 'pre' or 'post'")
 
-        if keep not in {"first", "last"}:
-            raise ValueError("Keep must be either 'first' or 'last'")
+        if preserve not in {"canonical", "incoming"}:
+            raise ValueError("preserve must be either 'canonical' or 'incoming'")
 
         if earnings_phase == "pre":
-            # Accounts for BMO row cases.
-            storage = storage[storage[DAYS_TO_EARNINGS_KEY_CAPITAL] > 0]
-        else: 
-            # Account for AMC row cases.
-            storage = storage[storage[DAYS_TO_EARNINGS_KEY_CAPITAL] <= -1]
+            storage = storage[storage[DAYS_TO_EARNINGS_KEY_CAPITAL] > 0].copy()
+        else:
+            storage = storage[storage[DAYS_TO_EARNINGS_KEY_CAPITAL] <= -1].copy()
+
+        if storage.empty:
+            print("No data to merge after filtering by earnings_phase")
+            return self.calendar
+
+        cal = self.calendar.copy()
+
+        # --- Critical fix: ensure dedupe keys exist as COLUMNS (not only in the index) ---
+        needed_keys = {FINVIZ_EARNINGS_DATE_KEY, TICKER_KEY_CAPITAL}
+
+        if not needed_keys.issubset(storage.columns):
+            storage = storage.reset_index()
+
+        if not needed_keys.issubset(cal.columns):
+            cal = cal.reset_index()
+
+        # Ensure DATADATE exists in both frames and is consistently datetime
+        if DATADATE_KEY not in storage.columns:
+            storage[DATADATE_KEY] = pd.NaT
+        if DATADATE_KEY not in cal.columns:
+            cal[DATADATE_KEY] = pd.NaT
+
+        storage[DATADATE_KEY] = pd.to_datetime(storage[DATADATE_KEY], errors="raise", format="mixed")
+        cal[DATADATE_KEY] = pd.to_datetime(cal[DATADATE_KEY], errors="raise", format="mixed")
+
+        # Preserve rule: canonical => calendar wins; incoming => storage wins
+        if preserve == "canonical":
+            cal["_src_pri"] = 1
+            storage["_src_pri"] = 0
+        else:  # preserve == "incoming"
+            cal["_src_pri"] = 0
+            storage["_src_pri"] = 1
+
+        merged = pd.concat([storage, cal], join="outer", ignore_index=True)
 
         self.merged_data = (
-            pd.concat([storage, self.calendar], join="outer")
+            merged
+            .sort_values(["_src_pri", DATADATE_KEY], ascending=[False, False], kind="mergesort")
+            .drop_duplicates(subset=[FINVIZ_EARNINGS_DATE_KEY, TICKER_KEY_CAPITAL], keep="first")
+            .drop(columns=["_src_pri"])
             .sort_values(DATADATE_KEY, ascending=False)
-            .reset_index()
-            .drop_duplicates(subset=[FINVIZ_EARNINGS_DATE_KEY, TICKER_KEY_CAPITAL], keep=keep)
             .set_index(FINVIZ_EARNINGS_DATE_KEY)
         )
 


### PR DESCRIPTION
Preserves canonical data at all cost and avoiding putting post earnings data into pre earnings table and the opposite 